### PR TITLE
Follow the 'connections' uri when present.

### DIFF
--- a/src/main/java/com/deere/isg/examples/Api.java
+++ b/src/main/java/com/deere/isg/examples/Api.java
@@ -1,0 +1,16 @@
+// Unpublished Work (c) 2020 Deere & Company
+package com.deere.isg.examples;
+
+import kong.unirest.Unirest;
+import kong.unirest.json.JSONObject;
+
+public class Api {
+    public JSONObject get(String accessToken, String resourceUrl) {
+        return Unirest.get(resourceUrl)
+                .header("authorization", "Bearer " + accessToken)
+                .accept("application/vnd.deere.axiom.v3+json")
+                .asJson()
+                .getBody()
+                .getObject();
+    }
+}

--- a/src/main/java/com/deere/isg/examples/Settings.java
+++ b/src/main/java/com/deere/isg/examples/Settings.java
@@ -12,6 +12,7 @@ public class Settings {
     public String clientId = "";
     public String clientSecret = "";
     public String wellKnown = "https://signin.johndeere.com/oauth2/aus78tnlaysMraFhC1t7/.well-known/oauth-authorization-server";
+    public String apiUrl = "https://sandboxapi.deere.com/platform";
     public String callbackUrl = "http://localhost:9090/callback";
     public String scopes = "openid profile offline_access ag1 eq1";
     public String state = "";

--- a/src/main/resources/templates/main.mustache
+++ b/src/main/resources/templates/main.mustache
@@ -122,7 +122,7 @@
             <div class="grid-item">
                 <label id="urlLabel" for="url"> Simple API Invoke With Token:</label>
                 <input type="url" id="url" name="url" aria-label="urlLabel"
-                       value="https://apiqa.tal.deere.com/platform/organizations"/>
+                       value="{{apiUrl}}/organizations"/>
             </div>
             <div class="grid-item">
                 <input type="submit" value="Go!">


### PR DESCRIPTION
* Full access to the API requires both user consent and designating
which organizations the user wants the application to be able to
interact with. Follow the 'connections' uri if present on any org to
allow the user finish the setup process.