### PR TITLE
Add the 'redirect_uri'.

### DIFF
--- a/src/main/java/com/deere/isg/examples/Application.java
+++ b/src/main/java/com/deere/isg/examples/Application.java
@@ -161,7 +161,7 @@ public class Application {
      * if no redirect is required to finish the setup.
      */
     @SuppressWarnings("unchecked")
-    private String needsOrganizationAccess() {
+    private String needsOrganizationAccess() throws URISyntaxException {
         JSONObject apiResponse = api.get(settings.accessToken, settings.apiUrl + "/organizations");
 
         List<JSONObject> values = apiResponse.getJSONArray("values").toList();
@@ -171,7 +171,9 @@ public class Application {
             for (JSONObject link : links) {
                 String linkType = link.getString("rel");
                 if (linkType.equals("connections")) {
-                    return link.getString("uri");
+                    URIBuilder uriBuilder = new URIBuilder(link.getString("uri"));
+                    uriBuilder.addParameter("redirect_uri", settings.orgConnectionCompletedUrl);
+                    return uriBuilder.build().toString();
                 }
             }
         }

--- a/src/main/java/com/deere/isg/examples/Settings.java
+++ b/src/main/java/com/deere/isg/examples/Settings.java
@@ -9,11 +9,13 @@ import java.util.Base64;
 import java.util.UUID;
 
 public class Settings {
+    private static String SERVER_URL = "http://localhost:9090";
     public String clientId = "";
     public String clientSecret = "";
     public String wellKnown = "https://signin.johndeere.com/oauth2/aus78tnlaysMraFhC1t7/.well-known/oauth-authorization-server";
     public String apiUrl = "https://sandboxapi.deere.com/platform";
-    public String callbackUrl = "http://localhost:9090/callback";
+    public String callbackUrl = SERVER_URL + "/callback";
+    public String orgConnectionCompletedUrl = SERVER_URL;
     public String scopes = "openid profile offline_access ag1 eq1";
     public String state = "";
     public String idToken;


### PR DESCRIPTION
* The connections app knows how to issue a redirct when the
select-organization is called with a `redirect_uri` query parameter.
This can send the user back the original app once they have completed
the organization selection process and makes exercising the api through
the demo app smoother.