### PR TITLE
Replace Spark with Javalin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,16 +78,17 @@
             <version>29.0-jre</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.javalin/javalin -->
         <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.9.1</version>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>3.13.4</version>
         </dependency>
 
         <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-template-mustache</artifactId>
-            <version>2.7.1</version>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>0.9.7</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,25 +88,7 @@
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
-            <version>3.13.4</version>
-        </dependency>
-
-        <!-- Can remove after Javalin gets its dependency updated -->
-        <!-- Jetty -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
-            <version>${jetty.version}</version>
+            <version>3.13.5</version>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
     <groupId>com.deere.isg.examples</groupId>
     <artifactId>oauth2-example</artifactId>
     <version>1.0</version>
+
+    <properties>
+        <jetty.version>9.4.39.v20210325</jetty.version>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -72,11 +76,13 @@
             <version>1.7.30</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>30.1.1-jre</version>
         </dependency>
+
 
         <!-- https://mvnrepository.com/artifact/io.javalin/javalin -->
         <dependency>
@@ -85,16 +91,36 @@
             <version>3.13.4</version>
         </dependency>
 
+        <!-- Can remove after Javalin gets its dependency updated -->
+        <!-- Jetty -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
             <version>0.9.7</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.konghq/unirest-java -->
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.4.00</version>
+            <version>3.11.11</version>
         </dependency>
+
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -104,5 +104,13 @@
             <version>3.11.11</version>
         </dependency>
 
+        <!-- Override Apache Version due to CVEs -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+
+
     </dependencies>
 </project>

--- a/src/main/java/com/deere/isg/examples/Application.java
+++ b/src/main/java/com/deere/isg/examples/Application.java
@@ -56,24 +56,23 @@ public class Application {
      * Updates the settings with the form an inits the OIDC login
      * @return
      */
-    private Object startOIDC(Context contex) {
-        settings.populate(contex);
+    private void startOIDC(Context context) {
+        settings.populate(context);
         String redirect = getRedirectUrl();
         logger.info("Authorization Link Built. Redirecting to : " + redirect);
-        contex.redirect(redirect);
-        return null;
+        context.redirect(redirect);
     }
 
-    private void processCallback(Context contex) {
+    private void processCallback(Context context) {
         logger.info("Processing callback from authorization server.");
-        if (!Strings.isNullOrEmpty(contex.queryParam("error"))) {
-            String description = contex.queryParam("error_description");
-            renderError(contex, description);
+        if (!Strings.isNullOrEmpty(context.queryParam("error"))) {
+            String description = context.queryParam("error_description");
+            renderError(context, description);
             return;
         }
 
         try {
-            String code = contex.queryParam("code");
+            String code = context.queryParam("code");
             logger.info("Found access code ({}) will use this to exchange for a access token", code);
             JSONObject obj = Unirest.post(getLocationFromMeta("token_endpoint"))
                     .header("authorization", "Basic " + settings.getBasicAuthHeader())
@@ -91,15 +90,13 @@ public class Application {
 
             String organizationAccessUrl = needsOrganizationAccess();
             if (organizationAccessUrl != null) {
-                contex.redirect(organizationAccessUrl);
+                context.redirect(organizationAccessUrl);
             }
-
+            index(context);
+            
         } catch (Exception e) {
-            renderError(contex, Throwables.getStackTraceAsString(e));
-            return;
+            renderError(context, Throwables.getStackTraceAsString(e));
         }
-
-        index(contex);
     }
 
     /**

--- a/src/main/java/com/deere/isg/examples/Application.java
+++ b/src/main/java/com/deere/isg/examples/Application.java
@@ -1,16 +1,18 @@
 package com.deere.isg.examples;
 
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+import io.javalin.plugin.rendering.template.JavalinMustache;
 import kong.unirest.Unirest;
 import kong.unirest.json.JSONObject;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import spark.ModelAndView;
-import spark.Request;
-import spark.Response;
-import spark.Spark;
-import spark.template.mustache.MustacheTemplateEngine;
+
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,7 +24,6 @@ import static com.google.common.collect.ImmutableMap.of;
 
 public class Application {
     private static final Logger logger = LoggerFactory.getLogger("oidc");
-    private MustacheTemplateEngine stache = new MustacheTemplateEngine();
     private Settings settings = new Settings();
     private Api api = new Api();
     private Map<String, JSONObject> metaInfo = new HashMap<>();
@@ -32,42 +33,47 @@ public class Application {
      */
     public void start() {
         int port = 9090;
-        Spark.port(port);
-        Spark.staticFileLocation("assets");
-        Spark.get("/", this::index);
-        Spark.post("/", this::startOIDC);
-        Spark.get("/callback", this::processCallback);
-        Spark.get("/refresh-access-token", this::refreshAccessToken);
-        Spark.post("/call-api", this::callTheApi);
+        Javalin app = Javalin.create(c -> {
+            c.addStaticFiles("assets/");
+
+        }).start(port);
+        DefaultMustacheFactory stache = new DefaultMustacheFactory("templates");
+        JavalinMustache.configure(stache);
+        app.get("/", this::index);
+        app.post("/", this::startOIDC);
+        app.get("/callback", this::processCallback);
+        app.get("/refresh-access-token", this::refreshAccessToken);
+        app.post("/call-api", this::callTheApi);
         logger.info("Application Stated please navigate to http://localhost:"+port);
         Unirest.config().interceptor(new LoggingInterceptor());
     }
 
-    public Object index(Request request, Response response) {
-        return stache.render(new ModelAndView(settings, "main.mustache"));
+    public void index(Context contex) {
+        contex.render("main.mustache", ImmutableMap.of("settings", settings));
     }
 
     /**
      * Updates the settings with the form an inits the OIDC login
      * @return
      */
-    private Object startOIDC(Request request, Response response) {
-        settings.populate(request);
+    private Object startOIDC(Context contex) {
+        settings.populate(contex);
         String redirect = getRedirectUrl();
         logger.info("Authorization Link Built. Redirecting to : " + redirect);
-        response.redirect(redirect);
+        contex.redirect(redirect);
         return null;
     }
 
-    private Object processCallback(Request request, Response response) {
+    private void processCallback(Context contex) {
         logger.info("Processing callback from authorization server.");
-        if (request.queryParams("error") != null) {
-            String description = request.queryParams("error_description");
-            return renderError(description);
+        if (!Strings.isNullOrEmpty(contex.queryParam("error"))) {
+            String description = contex.queryParam("error_description");
+            renderError(contex, description);
+            return;
         }
 
         try {
-            String code = request.queryParams("code");
+            String code = contex.queryParam("code");
             logger.info("Found access code ({}) will use this to exchange for a access token", code);
             JSONObject obj = Unirest.post(getLocationFromMeta("token_endpoint"))
                     .header("authorization", "Basic " + settings.getBasicAuthHeader())
@@ -85,14 +91,15 @@ public class Application {
 
             String organizationAccessUrl = needsOrganizationAccess();
             if (organizationAccessUrl != null) {
-                response.redirect(organizationAccessUrl);
+                contex.redirect(organizationAccessUrl);
             }
 
         } catch (Exception e) {
-            return renderError(Throwables.getStackTraceAsString(e));
+            renderError(contex, Throwables.getStackTraceAsString(e));
+            return;
         }
 
-        return index(request, response);
+        index(contex);
     }
 
     /**
@@ -129,7 +136,7 @@ public class Application {
                 .getObject();
     }
 
-    private Object refreshAccessToken(Request request, Response response) {
+    private void refreshAccessToken(Context context) {
         try {
             logger.info("Posting to refresh access token");
             JSONObject refresh = Unirest.post(getLocationFromMeta("token_endpoint"))
@@ -146,9 +153,10 @@ public class Application {
             logger.info("Refreshed token \n{}",refresh.toString(3));
             settings.updateTokenInfo(refresh);
         } catch (Exception e) {
-            return renderError(Throwables.getStackTraceAsString(e));
+            renderError(context, Throwables.getStackTraceAsString(e));
+            return;
         }
-        return index(request, response);
+        index(context);
     }
 
     /**
@@ -181,22 +189,23 @@ public class Application {
         return null;
     }
 
-    private Object callTheApi(Request request, Response response) {
-        String path = request.queryParams("url");
+    private void callTheApi(Context context) {
+        String path = context.queryParam("url");
         logger.info("Making api call");
         try {
             JSONObject apiResponse = api.get(settings.accessToken, path);
             settings.apiResponse = apiResponse.toString(3);
         } catch (Exception e) {
-            return renderError(Throwables.getStackTraceAsString(e));
+             renderError(context, Throwables.getStackTraceAsString(e));
+             return;
         }
-        return index(request, response);
+        index(context);
     }
 
-    private Object renderError(String errorMessage) {
+    private void renderError(Context context, String errorMessage) {
         logger.error(errorMessage);
-        return stache.render(
-                new ModelAndView(of("error", errorMessage), "error.mustache")
+        context.render("error.mustache",
+                of("error", Strings.nullToEmpty(errorMessage))
         );
     }
 }

--- a/src/main/java/com/deere/isg/examples/Settings.java
+++ b/src/main/java/com/deere/isg/examples/Settings.java
@@ -1,12 +1,14 @@
 package com.deere.isg.examples;
 
 import com.google.common.base.Strings;
+import io.javalin.http.Context;
 import kong.unirest.json.JSONObject;
-import spark.Request;
+
 
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.UUID;
+
 
 public class Settings {
     private static String SERVER_URL = "http://localhost:9090";
@@ -17,20 +19,20 @@ public class Settings {
     public String callbackUrl = SERVER_URL + "/callback";
     public String orgConnectionCompletedUrl = SERVER_URL;
     public String scopes = "openid profile offline_access ag1 eq1";
-    public String state = "";
+    public String state = UUID.randomUUID().toString();
     public String idToken;
     public String accessToken;
     public String refreshToken;
     public String apiResponse;
     public Long exp;
 
-    public void populate(Request request) {
-        this.clientId = request.queryParams("clientId");
-        this.clientSecret = request.queryParams("clientSecret");
-        this.wellKnown = request.queryParams("wellKnown");
-        this.callbackUrl = request.queryParams("callbackUrl");
-        this.scopes = request.queryParams("scopes");
-        this.state = request.queryParams("state");
+    public void populate(Context request) {
+        this.clientId = request.formParam("clientId");
+        this.clientSecret = request.formParam("clientSecret");
+        this.wellKnown = request.formParam("wellKnown");
+        this.callbackUrl = request.formParam("callbackUrl");
+        this.scopes = request.formParam("scopes");
+        this.state = request.formParam("state");
     }
 
     public String getAccessTokenDetails() {

--- a/src/main/resources/templates/main.mustache
+++ b/src/main/resources/templates/main.mustache
@@ -7,7 +7,7 @@
 <body>
 <h1>Welcome to the My John Deere API Java Example.</h1>
 
-
+{{#settings}}
 <div class="layout">
     <div class="grid-item">
         <div class="grid-container">
@@ -49,7 +49,7 @@
                     <input type="url"
                            name="callbackUrl"
                            id="callbackUrl"
-                           placeholder="The classback URL must be pre-registered with the client"
+                           placeholder="The callback URL must be pre-registered with the client"
                            aria-label="callBackLabel"
                            value="{{callbackUrl}}"
                            required>
@@ -140,6 +140,8 @@
 
     </div>
 {{/accessToken}}
+
+{{/settings}}
 
 <script type="text/javascript" src="/functions.js"></script>
 <script type="text/javascript" src="/prism.js"></script>


### PR DESCRIPTION
Spark has fallen on hard times and is not being maintained. It is starting to accumulate lots of transient CVEs. This replaces Spark with Javalin which is better maintained and is Spark's spiritual successor.